### PR TITLE
Rename cleanup variable

### DIFF
--- a/main.js
+++ b/main.js
@@ -166,10 +166,11 @@ class MaxxiCharge extends utils.Adapter {
 
     async cleanupActiveDevices() {
         const now = Date.now();
-        const fiveMinAgo = now - 90 * 1000;
+        // remove devices that haven't sent data in the last 90 seconds
+        const ninetySecAgo = now - 90 * 1000;
 
         for (const deviceId in this.activeDevices) {
-            if (this.activeDevices[deviceId] < fiveMinAgo) {
+            if (this.activeDevices[deviceId] < ninetySecAgo) {
                 delete this.activeDevices[deviceId];
                 this.log.warn(`Device ${deviceId} marked as inactive and removed.`);
             }


### PR DESCRIPTION
## Summary
- rename `fiveMinAgo` to `ninetySecAgo` in cleanupActiveDevices
- clarify comment about removing devices after 90 seconds

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6857c8742c6083338e1ccd7ba16443c2