### PR TITLE
Add validateInterval tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "io-package.json"
   ],
   "scripts": {
-    "test:js": "mocha --config test/mocharc.custom.json \"{!(node_modules|test)/**/*.test.js,*.test.js,test/**/test!(PackageFiles|Startup).js}\"",
+    "test:js": "mocha --config test/mocharc.custom.json \"{!(node_modules|test)/**/*.test.js,*.test.js,test/**/*.test.js,test/**/test!(PackageFiles|Startup).js}\"",
     "test:package": "mocha test/package --exit",
     "test:integration": "mocha test/integration --exit",
     "test": "npm run test:js && npm run test:package",

--- a/test/mocharc.custom.json
+++ b/test/mocharc.custom.json
@@ -5,6 +5,7 @@
     "watch-files": [
         "!(node_modules|test)/**/*.test.js",
         "*.test.js",
+        "test/**/*.test.js",
         "test/**/test!(PackageFiles|Startup).js"
     ]
 }

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,15 @@
+describe('validateInterval', () => {
+    const { validateInterval } = require('../utils');
+
+    it('should return the minimum when the value is too small', () => {
+        validateInterval(500, 1000, 5000).should.equal(1000);
+    });
+
+    it('should return the maximum when the value is too large', () => {
+        validateInterval(6000, 1000, 5000).should.equal(5000);
+    });
+
+    it('should return the value when it is within the range', () => {
+        validateInterval(3000, 1000, 5000).should.equal(3000);
+    });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `validateInterval`
- watch test files ending in `.test.js`
- run new tests via updated npm script

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857c8d4359c8333ab063a4943fa73c3