### PR TITLE
Fix log output in bkwMode

### DIFF
--- a/bkwMode.js
+++ b/bkwMode.js
@@ -65,7 +65,7 @@ class BkwMode {
             const dummyState = { val: targetValue };
             await this.commands.sendCommandWithRetry(ipAddress, 'baseLoad', dummyState, deviceId);
 
-            this.adapter.log.debug(`bkwMode: baseLoad set to -${targetValue} W (SOC=${soc}%).`);
+            this.adapter.log.debug(`bkwMode: baseLoad set to ${targetValue} W (SOC=${soc}%).`);
         }
     }
 


### PR DESCRIPTION
## Summary
- correct log message for BKW mode to show actual target value

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6857c8675db483338986c51cc8327b42