### PR TITLE
Übersetzungen: Offline-Text 'Data Forwarder zu Maxxisun' in allen Sprachen aktualisiert

### DIFF
--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -8,7 +8,7 @@
   "Maxxi CCU Name": "Maxxi CCU Name",
   "Enter the name of the Maxxi CCU (e.g., maxxi-XXXXXX-YYY).": "Geben Sie den Namen der Maxxi CCU ein (z. B. maxxi-XXXXXX-YYY).",
   "Local Configuration": "Local Konfiguration",
-  "Send local data to cloud for local operation with continued cloud availability.": "Lokale Daten an Cloud senden fur lokalen Betrieb bei weiterhin verfugbarer Cloud.",
+  "Send local data to cloud for local operation with continued cloud availability.": "Offline Betrieb - Data Forwarder zu Maxxisun:<br>Info: <i>Bleibt im sicheren Offline-Betrieb, sendet aber Daten nur zum Anzeigen in die Cloud.<br>Kein Zugriff von außen, nur Lesen über die App!</i>",
   "Port": "Port",
   "Define the port for the Local-API.": "Definieren Sie den Port, auf dem die API lauschen soll.",
   "On the MaxxiCharge config page under 'Api-Route', enter the following:": "Für die Nutzung des Local-API Dienstes folgendes bei Api-Route eingeben:",

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -8,7 +8,7 @@
   "Maxxi CCU Name": "Maxxi CCU Name",
   "Enter the name of the Maxxi CCU (e.g., maxxi-XXXXXX-YYY).": "Enter the name of the Maxxi CCU (e.g., maxxi-XXXXXX-YYY).",
   "Local Configuration": "Local Configuration",
-  "Send local data to cloud for local operation with continued cloud availability.": "Send local data to cloud for local operation with continued cloud availability.",
+  "Send local data to cloud for local operation with continued cloud availability.": "Offline operation - Data Forwarder to Maxxisun:<br>Info: <i>Stays in secure offline mode, but sends data to the cloud for display only.<br>No external access, read-only via the app!</i>",
   "Port": "Port",
   "Define the port for the Local-API.": "Define the port for the API to listen on.",
   "On the MaxxiCharge config page under 'Api-Route', enter the following:": "On the MaxxiCharge config page under 'Api-Route', enter the following:",

--- a/admin/i18n/es/translations.json
+++ b/admin/i18n/es/translations.json
@@ -8,7 +8,7 @@
   "Maxxi CCU Name": "Maxxi CCU Name",
   "Enter the name of the Maxxi CCU (e.g., maxxi-XXXXXX-YYY).": "Enter the name of the Maxxi CCU (e.g., maxxi-XXXXXX-YYY).",
   "Local Configuration": "Local Configuration",
-  "Send local data to cloud for local operation with continued cloud availability.": "Enviar datos locales a la nube para funcionamiento local manteniendo la disponibilidad en la nube.",
+  "Send local data to cloud for local operation with continued cloud availability.": "Funcionamiento offline - Reenviador de datos a Maxxisun:<br>Info: <i>Permanece en modo offline seguro, pero envía datos a la nube solo para visualización.<br>Sin acceso externo, solo lectura mediante la app.</i>",
   "Port": "Port",
   "Define the port for the Local-API.": "Define the port for the API to listen on.",
   "On the MaxxiCharge config page under 'Api-Route', enter the following:": "On the MaxxiCharge config page under 'Api-Route', enter the following:",

--- a/admin/i18n/fr/translations.json
+++ b/admin/i18n/fr/translations.json
@@ -8,7 +8,7 @@
   "Maxxi CCU Name": "Maxxi CCU Name",
   "Enter the name of the Maxxi CCU (e.g., maxxi-XXXXXX-YYY).": "Enter the name of the Maxxi CCU (e.g., maxxi-XXXXXX-YYY).",
   "Local Configuration": "Local Configuration",
-  "Send local data to cloud for local operation with continued cloud availability.": "Envoyer les donnees locales vers le cloud pour un fonctionnement local tout en conservant la disponibilite du cloud.",
+  "Send local data to cloud for local operation with continued cloud availability.": "Mode hors ligne - Transmetteur de données vers Maxxisun :<br>Info : <i>Reste en mode hors ligne sécurisé, mais envoie des données au cloud uniquement pour affichage.<br>Aucun accès externe, lecture seule via l'application !</i>",
   "Port": "Port",
   "Define the port for the Local-API.": "Define the port for the API to listen on.",
   "On the MaxxiCharge config page under 'Api-Route', enter the following:": "On the MaxxiCharge config page under 'Api-Route', enter the following:",

--- a/admin/i18n/it/translations.json
+++ b/admin/i18n/it/translations.json
@@ -8,7 +8,7 @@
   "Maxxi CCU Name": "Maxxi CCU Name",
   "Enter the name of the Maxxi CCU (e.g., maxxi-XXXXXX-YYY).": "Enter the name of the Maxxi CCU (e.g., maxxi-XXXXXX-YYY).",
   "Local Configuration": "Local Configuration",
-  "Send local data to cloud for local operation with continued cloud availability.": "Inviare i dati locali al cloud per il funzionamento locale mantenendo la disponibilita del cloud.",
+  "Send local data to cloud for local operation with continued cloud availability.": "Modalità offline - Inoltro dati a Maxxisun:<br>Info: <i>Rimane in modalità offline sicura, ma invia i dati al cloud solo per la visualizzazione.<br>Nessun accesso esterno, sola lettura tramite app!</i>",
   "Port": "Port",
   "Define the port for the Local-API.": "Define the port for the API to listen on.",
   "On the MaxxiCharge config page under 'Api-Route', enter the following:": "On the MaxxiCharge config page under 'Api-Route', enter the following:",

--- a/admin/i18n/nl/translations.json
+++ b/admin/i18n/nl/translations.json
@@ -8,7 +8,7 @@
   "Maxxi CCU Name": "Maxxi CCU Name",
   "Enter the name of the Maxxi CCU (e.g., maxxi-XXXXXX-YYY).": "Enter the name of the Maxxi CCU (e.g., maxxi-XXXXXX-YYY).",
   "Local Configuration": "Local Configuration",
-  "Send local data to cloud for local operation with continued cloud availability.": "Lokale gegevens naar de cloud sturen voor lokaal gebruik met behoud van cloudbeschikbaarheid.",
+  "Send local data to cloud for local operation with continued cloud availability.": "Offline werking - Data Forwarder naar Maxxisun:<br>Info: <i>Blijft in veilige offline werking, maar stuurt gegevens alleen naar de cloud voor weergave.<br>Geen externe toegang, alleen-lezen via de app!</i>",
   "Port": "Port",
   "Define the port for the Local-API.": "Define the port for the API to listen on.",
   "On the MaxxiCharge config page under 'Api-Route', enter the following:": "On the MaxxiCharge config page under 'Api-Route', enter the following:",

--- a/admin/i18n/pl/translations.json
+++ b/admin/i18n/pl/translations.json
@@ -8,7 +8,7 @@
   "Maxxi CCU Name": "Maxxi CCU Name",
   "Enter the name of the Maxxi CCU (e.g., maxxi-XXXXXX-YYY).": "Enter the name of the Maxxi CCU (e.g., maxxi-XXXXXX-YYY).",
   "Local Configuration": "Local Configuration",
-  "Send local data to cloud for local operation with continued cloud availability.": "Wysylaj lokalne dane do chmury dla pracy lokalnej z zachowaniem dostepnosci chmury.",
+  "Send local data to cloud for local operation with continued cloud availability.": "Tryb offline - Przekazywanie danych do Maxxisun:<br>Info: <i>Pozostaje w bezpiecznym trybie offline, ale wysyła dane do chmury wyłącznie do podglądu.<br>Brak dostępu z zewnątrz, tylko odczyt przez aplikację!</i>",
   "Port": "Port",
   "Define the port for the Local-API.": "Define the port for the API to listen on.",
   "On the MaxxiCharge config page under 'Api-Route', enter the following:": "On the MaxxiCharge config page under 'Api-Route', enter the following:",

--- a/admin/i18n/pt/translations.json
+++ b/admin/i18n/pt/translations.json
@@ -8,7 +8,7 @@
   "Maxxi CCU Name": "Maxxi CCU Name",
   "Enter the name of the Maxxi CCU (e.g., maxxi-XXXXXX-YYY).": "Enter the name of the Maxxi CCU (e.g., maxxi-XXXXXX-YYY).",
   "Local Configuration": "Local Configuration",
-  "Send local data to cloud for local operation with continued cloud availability.": "Enviar dados locais para a nuvem para operacao local mantendo a disponibilidade na nuvem.",
+  "Send local data to cloud for local operation with continued cloud availability.": "Operação offline - Encaminhamento de dados para Maxxisun:<br>Info: <i>Permanece em modo offline seguro, mas envia dados para a nuvem apenas para visualização.<br>Sem acesso externo, somente leitura pelo app!</i>",
   "Port": "Port",
   "Define the port for the Local-API.": "Define the port for the API to listen on.",
   "On the MaxxiCharge config page under 'Api-Route', enter the following:": "On the MaxxiCharge config page under 'Api-Route', enter the following:",

--- a/admin/i18n/ru/translations.json
+++ b/admin/i18n/ru/translations.json
@@ -8,7 +8,7 @@
   "Maxxi CCU Name": "Maxxi CCU Name",
   "Enter the name of the Maxxi CCU (e.g., maxxi-XXXXXX-YYY).": "Enter the name of the Maxxi CCU (e.g., maxxi-XXXXXX-YYY).",
   "Local Configuration": "Local Configuration",
-  "Send local data to cloud for local operation with continued cloud availability.": "Otpravlyat lokalnye dannye v oblako dlya lokalnoy raboty s sokhraneniem dostupnosti oblaka.",
+  "Send local data to cloud for local operation with continued cloud availability.": "Офлайн-режим - Передача данных в Maxxisun:<br>Инфо: <i>Остается в безопасном офлайн-режиме, но отправляет данные в облако только для отображения.<br>Внешний доступ отсутствует, только чтение через приложение!</i>",
   "Port": "Port",
   "Define the port for the Local-API.": "Define the port for the API to listen on.",
   "On the MaxxiCharge config page under 'Api-Route', enter the following:": "On the MaxxiCharge config page under 'Api-Route', enter the following:",

--- a/admin/i18n/uk/translations.json
+++ b/admin/i18n/uk/translations.json
@@ -8,7 +8,7 @@
   "Maxxi CCU Name": "Maxxi CCU Name",
   "Enter the name of the Maxxi CCU (e.g., maxxi-XXXXXX-YYY).": "Enter the name of the Maxxi CCU (e.g., maxxi-XXXXXX-YYY).",
   "Local Configuration": "Local Configuration",
-  "Send local data to cloud for local operation with continued cloud availability.": "Nadsylaty lokalni dani do khmary dlya lokalnoyi roboty zi zberezhennyam dostupnosti khmary.",
+  "Send local data to cloud for local operation with continued cloud availability.": "Офлайн-режим - Передача даних до Maxxisun:<br>Інфо: <i>Працює у безпечному офлайн-режимі, але надсилає дані в хмару лише для відображення.<br>Жодного зовнішнього доступу, лише читання через застосунок!</i>",
   "Port": "Port",
   "Define the port for the Local-API.": "Define the port for the API to listen on.",
   "On the MaxxiCharge config page under 'Api-Route', enter the following:": "On the MaxxiCharge config page under 'Api-Route', enter the following:",

--- a/admin/i18n/zh-cn/translations.json
+++ b/admin/i18n/zh-cn/translations.json
@@ -8,7 +8,7 @@
   "Maxxi CCU Name": "Maxxi CCU Name",
   "Enter the name of the Maxxi CCU (e.g., maxxi-XXXXXX-YYY).": "Enter the name of the Maxxi CCU (e.g., maxxi-XXXXXX-YYY).",
   "Local Configuration": "Local Configuration",
-  "Send local data to cloud for local operation with continued cloud availability.": "将本地数据发送到云端，以便在本地运行的同时保持云端可用性。",
+  "Send local data to cloud for local operation with continued cloud availability.": "离线运行 - 数据转发到 Maxxisun：<br>说明：<i>保持安全离线运行，但仅将数据发送到云端用于显示。<br>无外部访问，仅可通过 App 只读查看！</i>",
   "Port": "Port",
   "Define the port for the Local-API.": "Define the port for the API to listen on.",
   "On the MaxxiCharge config page under 'Api-Route', enter the following:": "On the MaxxiCharge config page under 'Api-Route', enter the following:",


### PR DESCRIPTION
### Motivation
- Der bestehende Text für den Schlüssel `"Send local data to cloud for local operation with continued cloud availability."` sollte im Deutschen durch die gewünschte Formulierung ersetzt werden und in allen Sprachen sinngemäß gleichlautend sein.
- Lesbarkeit verbessern durch bewusste Zeilenumbrüche nach „Maxxisun:“ und nach dem Hinweis zur Cloud.
- HTML-Formatierung (italics) korrekt schließen und konsistente Anzeige in der Admin-Oberfläche sicherstellen.

### Description
- Ersetzte den Wert des Schlüssels `"Send local data to cloud for local operation with continued cloud availability."` in allen Dateien `admin/i18n/*/translations.json` (Sprachen: `de`, `en`, `es`, `fr`, `it`, `nl`, `pl`, `pt`, `ru`, `uk`, `zh-cn`) durch die neue Formulierung mit `Maxxisun` und den gewünschten `<br>`-Zeilenumbrüchen.
- Die neue Textformulierung verwendet jetzt explizit: "Offline Betrieb - Data Forwarder zu Maxxisun:" gefolgt von einem Info-Abschnitt in Italic (`<i>...</i>`), wobei das `</i>` korrekt geschlossen wurde.
- Einheitliche, sinngetreue Übersetzungen für alle unterstützten Sprachen angelegt, sodass die Bedeutung in jeder Locale gleich ist.
- Änderungen wurden in 11 Übersetzungsdateien aktualisiert (`admin/i18n/<lang>/translations.json`).

### Testing
- Automatisierte Tests mit `npm test` ausgeführt und erfolgreich abgeschlossen.
- Ergebnis: alle Unit- und Paketprüfungen erfolgreich; insgesamt `57 passing` (JS-Tests + Paket-/i18n-Validierung).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bda444da7483339bdc14316d6a821e)