### PR TITLE
chore: .npmrc hinzufügen, um npm-Git-Installationsfehler zu vermeiden

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+prefer-offline=false
+prefer-online=false
+offline=false


### PR DESCRIPTION
### Motivation
- Beim Installationsfehler trat `--prefer-online cannot be provided when using --prefer-offline` bei npm 11 bei Git-basierten Adapter-Installationen auf, was auf widersprüchliche npm-Preferences hindeutet.
- Ziel ist, deterministische npm-Defaults für Repository-Installationen zu liefern, damit `iobroker url <github-repo>` zuverlässig läuft.

### Description
- Eine Repository-weit gültige Datei `/.npmrc` wurde hinzugefügt, die `prefer-offline=false`, `prefer-online=false` und `offline=false` setzt.
- Die Änderung ist rein konfigurationsorientiert und verändert keine Laufzeit- oder Adapterlogik.

### Testing
- Es wurde `npm --version` geprüft und die Umgebung validiert, wobei `v22.21.1` und `npm 11.x` bestätigt wurden, und dieser Schritt erfolgreich war.
- Ein Dry-Run mit den problematischen Flags wurde ausgeführt: `npm install --dry-run --prefer-offline=false --prefer-online=false --offline=false ...` und der Dry-Run lief erfolgreich durch.
- Ein realer Testinstall aus einem temporären Projekt mit `npm install --prefer-offline=false --prefer-online=false git+file:///workspace/ioBroker.maxxi-charge` wurde durchgeführt und die Installation war erfolgreich.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d13d45e9088333b96aca7c292bc883)